### PR TITLE
Add continous integration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,15 @@
+name: Rust
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: Rust
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,8 +8,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
     - uses: actions/checkout@v1
+
+    - name: Prepare
+      run: sudo apt-get install -y libdbus-1-dev pkg-config
+
     - name: Build
       run: cargo build --verbose
+
     - name: Run tests
       run: cargo test --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 logs/*
 test_c_service/test_service
+.idea/

--- a/src/dbus_wait.rs
+++ b/src/dbus_wait.rs
@@ -100,6 +100,7 @@ fn name_exists(name: &str, obj: &Proxy<&Connection>) -> Result<bool, Box<dyn std
 }
 
 #[test]
+#[ignore]
 fn test_dbus_wait() {
     let name = "This.Is.A.Test.Name".to_owned();
     let name2 = name.clone();


### PR DESCRIPTION
Setting up a continuous integration helps to see build or test failures early