### PR TITLE
RFC: Add support for setting execution environment variables

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -4,4 +4,4 @@ cargo build
 # cargo build --target x86_64-unknown-redox
 
 cd test_c_service
-clang -o test_service test_service.c $(pkg-config libsystemd --libs)
+gcc -o test_service test_service.c $(pkg-config libsystemd --libs)

--- a/src/bin/rustysd.rs
+++ b/src/bin/rustysd.rs
@@ -112,7 +112,7 @@ fn pid1_specific_setup() {}
 fn prepare_runtimeinfo(conf: &config::Config, dry_run: bool) -> runtime_info::ArcMutRuntimeInfo {
     // initial loading of the units and matching of the various before/after settings
     // also opening all fildescriptors in the socket files
-    let unit_table = units::load_all_units(&conf.unit_dirs, &conf.target_unit).unwrap();
+    let unit_table = units::load_all_units(&conf.unit_dirs, &conf.target_unit).expect("loading unit files");
     trace!("Finished loading units");
     if let Err(e) = units::sanity_check_dependencies(&unit_table) {
         match e {

--- a/src/units/from_parsed_config.rs
+++ b/src/units/from_parsed_config.rs
@@ -197,6 +197,7 @@ impl std::convert::TryFrom<ParsedExecSection> for ExecConfig {
             supplementary_groups: supp_gids,
             stderr_path: parsed.stderr_path,
             stdout_path: parsed.stdout_path,
+            environment: parsed.environment,
         })
     }
 }

--- a/src/units/unit.rs
+++ b/src/units/unit.rs
@@ -851,6 +851,7 @@ pub struct ExecConfig {
     pub supplementary_groups: Vec<nix::unistd::Gid>,
     pub stdout_path: Option<StdIoOption>,
     pub stderr_path: Option<StdIoOption>,
+    pub environment: Option<EnvVars>,
 }
 
 #[cfg(target_os = "linux")]

--- a/src/units/unit_parsing/mod.rs
+++ b/src/units/unit_parsing/mod.rs
@@ -92,6 +92,7 @@ pub struct ParsedExecSection {
     pub stdout_path: Option<StdIoOption>,
     pub stderr_path: Option<StdIoOption>,
     pub supplementary_groups: Vec<String>,
+    pub environment: Option<EnvVars>,
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
@@ -143,6 +144,11 @@ pub struct Commandline {
     pub cmd: String,
     pub args: Vec<String>,
     pub prefixes: Vec<CommandlinePrefix>,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct EnvVars {
+    pub vars: Vec<(String, String)>,
 }
 
 impl ToString for Commandline {

--- a/test_c_service/test_service.c
+++ b/test_c_service/test_service.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <systemd/sd-daemon.h>
 #include <unistd.h>
 #include <string.h>
@@ -26,6 +27,8 @@ int main(int argc, char **argv) {
           printf("\tFD #%d  Fifo socket test (should be 1): %d\n", i, sd_is_fifo(i+3, "./sockets/cservice.fifo"));
       }
   }
+
+  printf("Env var VAR1: %s\tVAR2: %s\tVAR3: %s\n", getenv("VAR1"), getenv("VAR2"), getenv("VAR3"));
 
   int res = sd_notify(0, "READY=1\n");
   printf("Result of sd_notify: %d\n", res);

--- a/test_units/cservice.service
+++ b/test_units/cservice.service
@@ -3,6 +3,7 @@ ExecStart= ./test_c_service/test_service  arg1 arg2
 Sockets= cservice.socket
 NotifyAccess= all
 Type= notify
+Environment="VAR1=word1 word2" VAR2=word3 "VAR3=$word 5 6"
 Restart= always
 
 [Install]


### PR DESCRIPTION
Hello! While playing around with `rustysd` (awesome project :) ), I was tinkering with adding a simple-ish service configuration option and added support for `Environment=`. Would you be open to upstreaming this?